### PR TITLE
Update test for new location of gocheck

### DIFF
--- a/httpcache_test.go
+++ b/httpcache_test.go
@@ -2,7 +2,7 @@ package httpcache
 
 import (
 	"fmt"
-	. "launchpad.net/gocheck"
+	. "gopkg.in/check.v1"
 	"net"
 	"net/http"
 	"testing"


### PR DESCRIPTION
The gocheck project has moved and recommends this versioned import path.

Tests pass 
